### PR TITLE
More Answered Questions button complete with QandA scrolling

### DIFF
--- a/client/dist/QAStyle.css
+++ b/client/dist/QAStyle.css
@@ -1,3 +1,8 @@
+.QandAList {
+  height: 100vh;
+  overflow: scroll;
+}
+
 .seller {
   font-weight: bold;
 }
@@ -5,4 +10,8 @@
 .QandAAnswerPhoto {
   max-width: 100px;
   max-height: 100px;
+}
+
+#moreQuestionsButton {
+  visibility: visible;
 }

--- a/client/src/Components/QuestionsAndAnswers/AnswersList.jsx
+++ b/client/src/Components/QuestionsAndAnswers/AnswersList.jsx
@@ -51,8 +51,8 @@ class AnswersList extends React.Component {
                 return <li key={index}>
                   <p className='QandAAnswerBody'>{answer.body}</p>
                   {
-                    answer.photos.map((photo) => {
-                      return <img className='QandAAnswerPhoto' src={photo.url} />
+                    answer.photos.map((photo, index) => {
+                      return <img key={index} className='QandAAnswerPhoto' src={photo.url} />
                     })
                   }
                   {answerer}

--- a/client/src/Components/QuestionsAndAnswers/QandA.jsx
+++ b/client/src/Components/QuestionsAndAnswers/QandA.jsx
@@ -32,16 +32,41 @@ class QandA extends React.Component {
     }).catch((err) => {console.log('Error getting questions from API: ' + err)});
   }
 
+  //method for click of "More Answered Questions" button to make more questions visible
+  showMoreQuestions() {
+    var hiddenQuestions = document.getElementsByClassName('moreQuestions');
+    var questionsButton = document.getElementById('moreQuestionsButton');
+
+    for (var currentElement = 0; currentElement < 2; currentElement++) {
+      if(hiddenQuestions[currentElement] !== undefined) {
+        hiddenQuestions[currentElement].classList.remove('moreQuestions');
+      }
+    }
+    if(hiddenQuestions.length === 0) {
+      questionsButton.style.visibility = 'collapse';
+    }
+  }
+
   render() {
+    var questionsButton;
+
+    if(this.state.questions.length > 2) {
+      var questionsButton = <button id='moreQuestionsButton' onClick={this.showMoreQuestions}>More Answered Questions</button>;
+    }
+
     return (
       <div id="QandA">
+        <h2 className='QandATitle'>Questions & Answers</h2>
+        <div className='QandAList'>
         {
           this.state.questions.map((question, index) => {
             return (
-            <Question key={index} question={question} apiUrl={this.props.apiUrl} token={this.props.token} trackClicks={this.props.trackClicks}/>
+            <Question key={index} question={question} apiUrl={this.props.apiUrl} token={this.props.token} trackClicks={this.props.trackClicks} index={index}/>
             )
           })
         }
+        </div>
+        {questionsButton}
       </div>
     )
   }


### PR DESCRIPTION
The button successfully shows up when there are more than 2 questions and renders 2 more questions in the list when clicked. If there are no more hidden questions, the button disappears. If there are only 2 questions or less the button never appears. The Questions list in QandA is now scroll-able if the height of the list div exceeds the height of the screen. 