### PR TITLE
Yes link click increases helpfulness by 1, once only

### DIFF
--- a/client/dist/QAStyle.css
+++ b/client/dist/QAStyle.css
@@ -1,6 +1,6 @@
 .QandAList {
   height: 100vh;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .seller {
@@ -18,10 +18,15 @@
 
 .moreAnswers {
   visibility: collapse;
-  font-size: 0; 
+  font-size: 0;
 }
 
 .moreQuestions {
   font-size: 0;
   visibility: collapse;
+}
+
+.QandAYes {
+  cursor: pointer;
+  text-decoration: underline;
 }

--- a/client/src/Components/QuestionsAndAnswers/AnswersList.jsx
+++ b/client/src/Components/QuestionsAndAnswers/AnswersList.jsx
@@ -76,7 +76,10 @@ class AnswersList extends React.Component {
                   <p className='timeAnswered'>{monthName + ' ' + day + ', ' + year}</p>
                   <p> | </p>
                   <p className='QandAHelpfulAnswer'>Helpful? </p>
-                  <a className='QandAyes' onClick={(event) => { this.props.trackClicks(event, 'Questions & Answers'); }}>Yes ({answer.helpfulness})</a>
+                  <p className='QandAyes' onClick={(event) => {
+                    this.props.trackClicks(event, 'Questions & Answers');
+                    event.target.textContent = `Yes (${answer.helpfulness + 1})`;
+                  }}>Yes ({answer.helpfulness})</p>
                   <p> | </p>
                   <p className='QandAreportAnswer'>Report</p>
                 </li>
@@ -87,7 +90,10 @@ class AnswersList extends React.Component {
                   <p className='timeAnswered'>{monthName + ' ' + day + ', ' + year}</p>
                   <p> | </p>
                   <p className='QandAHelpfulAnswer'>Helpful? </p>
-                  <a className='QandAyes' onClick={(event) => { this.props.trackClicks(event, 'Questions & Answers'); }}>Yes ({answer.helpfulness})</a>
+                  <a className='QandAyes' onClick={(event) => {
+                    this.props.trackClicks(event, 'Questions & Answers');
+                    event.target.textContent = `Yes (${answer.helpfulness + 1})`;
+                  }}>Yes ({answer.helpfulness})</a>
                   <p> | </p>
                   <p className='QandAreportAnswer'>Report</p>
                 </li>

--- a/client/src/Components/QuestionsAndAnswers/QandA.jsx
+++ b/client/src/Components/QuestionsAndAnswers/QandA.jsx
@@ -51,7 +51,7 @@ class QandA extends React.Component {
     var questionsButton;
 
     if(this.state.questions.length > 2) {
-      var questionsButton = <button id='moreQuestionsButton' onClick={this.showMoreQuestions}>More Answered Questions</button>;
+      var questionsButton = <button id='moreQuestionsButton' onClick={ (event) => { this.showMoreQuestions(); this.props.trackClicks(event, 'Questions & Answers'); }}>More Answered Questions</button>;
     }
 
     return (

--- a/client/src/Components/QuestionsAndAnswers/Question.jsx
+++ b/client/src/Components/QuestionsAndAnswers/Question.jsx
@@ -13,7 +13,10 @@ class Question extends React.Component {
         <div className='QuestionComponent' data-testid='QuestionComponent'>
           <h2>Q: {this.props.question.question_body}</h2>
           <p className='QandAHelpfulQuestion'>Helpful?</p>
-          <p className='QandAyes'>Yes ({this.props.question.question_helpfulness})</p>
+          <p className='QandAyes' onClick={ (event) => {
+            this.props.trackClicks(event, 'Questions & Answers');
+            event.target.textContent = `Yes (${this.props.question.question_helpfulness + 1})`;
+          }}>Yes ({this.props.question.question_helpfulness})</p>
           <p> | </p>
           <p className='QandAAddAnswer'>Add Answer</p>
           <AnswersList id={this.props.question.question_id} apiUrl={this.props.apiUrl} token={this.props.token} trackClicks={this.props.trackClicks}/>
@@ -24,7 +27,10 @@ class Question extends React.Component {
         <div className='QuestionComponent moreQuestions' data-testid='QuestionComponent'>
           <h2>Q: {this.props.question.question_body}</h2>
           <p className='QandAHelpfulQuestion'>Helpful?</p>
-          <p className='QandAyes'>Yes ({this.props.question.question_helpfulness})</p>
+          <p className='QandAyes' onClick={ (event) => {
+            this.props.trackClicks(event, 'Questions & Answers');
+            event.target.textContent = `Yes (${this.props.question.question_helpfulness + 1})`;
+          }}>Yes ({this.props.question.question_helpfulness})</p>
           <p> | </p>
           <p className='QandAAddAnswer'>Add Answer</p>
           <AnswersList id={this.props.question.question_id} apiUrl={this.props.apiUrl} token={this.props.token} trackClicks={this.props.trackClicks}/>


### PR DESCRIPTION
- Yes link, when clicked increases helpfulness by 1, works only once per refresh
- Set CSS for yes links (underlined and cursor set to pointer on hover)
- Added click tracking to all yes links and "More Answered Questions" button
- Changed QandAList CSS (overflow: auto)