### PR TITLE
QandA SearchBar component complete

### DIFF
--- a/client/dist/QAStyle.css
+++ b/client/dist/QAStyle.css
@@ -1,5 +1,5 @@
 .QandAList {
-  height: 100vh;
+  max-height: 100vh;
   overflow: scroll;
 }
 
@@ -18,10 +18,18 @@
 
 .moreAnswers {
   visibility: collapse;
-  font-size: 0; 
+  font-size: 0;
 }
 
 .moreQuestions {
   font-size: 0;
   visibility: collapse;
+}
+
+.searchBar {
+  width: 300px;
+}
+
+.resultNotFound {
+  visibility: hidden;
 }

--- a/client/src/Components/QuestionsAndAnswers/QandA.jsx
+++ b/client/src/Components/QuestionsAndAnswers/QandA.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import ReactDom from 'react-dom';
-import Question from './Question.jsx';
 import axios from 'axios';
+import Question from './Question.jsx';
+import SearchBar from './SearchBar.jsx';
 
 class QandA extends React.Component {
   constructor(props) {
@@ -57,6 +58,7 @@ class QandA extends React.Component {
     return (
       <div id="QandA">
         <h2 className='QandATitle'>Questions & Answers</h2>
+        <SearchBar questions={this.state.questions} trackClicks={this.props.trackClicks}/>
         <div className='QandAList'>
         {
           this.state.questions.map((question, index) => {

--- a/client/src/Components/QuestionsAndAnswers/Question.jsx
+++ b/client/src/Components/QuestionsAndAnswers/Question.jsx
@@ -11,7 +11,7 @@ class Question extends React.Component {
     if (this.props.index < 2) {
       return (
         <div className='QuestionComponent' data-testid='QuestionComponent'>
-          <h2>Q: {this.props.question.question_body}</h2>
+          <h2 className='questionBody'>Q: {this.props.question.question_body}</h2>
           <p className='QandAHelpfulQuestion'>Helpful?</p>
           <p className='QandAyes'>Yes ({this.props.question.question_helpfulness})</p>
           <p> | </p>
@@ -22,7 +22,7 @@ class Question extends React.Component {
     } else {
       return (
         <div className='QuestionComponent moreQuestions' data-testid='QuestionComponent'>
-          <h2>Q: {this.props.question.question_body}</h2>
+          <h2 className='questionBody'>Q: {this.props.question.question_body}</h2>
           <p className='QandAHelpfulQuestion'>Helpful?</p>
           <p className='QandAyes'>Yes ({this.props.question.question_helpfulness})</p>
           <p> | </p>

--- a/client/src/Components/QuestionsAndAnswers/SearchBar.jsx
+++ b/client/src/Components/QuestionsAndAnswers/SearchBar.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+class SearchBar extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  //method to filter questions on change of text in the search bar with 3 or more characters
+  onChangeFilter(event) {
+    var questionsOnDOM = document.getElementsByClassName('QuestionComponent');
+    var noResultsElement = document.getElementsByClassName('resultNotFound')[0];
+    var resultFound = false;
+
+    if (event.target.value.length >= 3) {
+
+      for (var question = 0; question < questionsOnDOM.length; question++) {
+        if (questionsOnDOM[question].children[0].textContent.includes(event.target.value)) {
+          if (questionsOnDOM[question].classList.contains('moreQuestions')) {
+            questionsOnDOM[question].classList.remove('moreQuestions');
+          }
+          resultFound = true;
+        } else {
+          questionsOnDOM[question].classList.add('moreQuestions');
+        }
+      }
+
+      if (!resultFound) {
+        noResultsElement.style.visibility = 'visible';
+      } else {
+        noResultsElement.style.visibility = 'hidden';
+      }
+    } else {
+      for (var question = 0; question < 2; question++) {
+        if(questionsOnDOM[question] !== undefined) {
+          questionsOnDOM[question].classList.remove('moreQuestions');
+        }
+      }
+    }
+  }
+
+  render() {
+    return (
+      <div className='searchBarDiv'>
+        <input className='searchBar' type='text' placeholder='Have a question? Search for answers…'
+        onClick={ (event) => { this.props.trackClicks(event, 'Questions & Answers'); }}
+        onChange={ (event) => { this.onChangeFilter(event) }}></input>
+        <p className='resultNotFound'>No Results</p>
+      </div>
+    )
+  }
+}
+
+export default SearchBar;


### PR DESCRIPTION
Search bar added to QandA that filters the questions list based on the input text only if there are 3 or more characters. If 3+ characters, the list is filtered every time the input text is changed. If no text is typed into input, a placeholder displays with a text value of "Have a question? Search for answers...". If 3+ characters are typed and the list is filtered, when characters are removed and length is 2 or less the questions are no longer filtered. If there is a search that has no matching results, "No results" is displayed below the bar. QandAList CSS property "height" changed to "max-height" so that the questions list can render as smaller than, but no larger than 100vh.
